### PR TITLE
Set platform as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @freestarcapital/platform


### PR DESCRIPTION
Sets root CODEOWNERS to `* @freestarcapital/platform` per the repo-ownership audit (PLAT-1585).